### PR TITLE
Split flow controller

### DIFF
--- a/cmd/flowscontroller/main.go
+++ b/cmd/flowscontroller/main.go
@@ -57,12 +57,16 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var configMapNamespace string
+	var configMapName string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", false,
 		"If set the metrics endpoint is served securely")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.StringVar(&configMapNamespace, "cm-namespace", "default", "Spectrum-x config map namespace")
+	flag.StringVar(&configMapName, "cm-name", "specx-config", "Spectrum-x config map name")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -112,13 +116,27 @@ func main() {
 	}
 
 	if err = (&controller.FlowReconciler{
-		NodeName: Options.NodeName,
-		Client:   mgr.GetClient(),
-		Exec:     &exec.Exec{},
+		NodeName:           Options.NodeName,
+		Client:             mgr.GetClient(),
+		Exec:               &exec.Exec{},
+		ConfigMapNamespace: configMapNamespace,
+		ConfigMapName:      configMapName,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Pod")
 		os.Exit(1)
 	}
+
+	if err = (&controller.HostConfigReconciler{
+		NodeName:           Options.NodeName,
+		Client:             mgr.GetClient(),
+		Exec:               &exec.Exec{},
+		ConfigMapNamespace: configMapNamespace,
+		ConfigMapName:      configMapName,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "HostConfig")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/flowcontroller/daemonset.yaml
+++ b/config/flowcontroller/daemonset.yaml
@@ -20,14 +20,19 @@ spec:
         control-plane: flowcontroller
     spec:
       securityContext:
-        runAsNonRoot: False
+        runAsNonRoot: false
       containers:
       - command:
         - /flowcontroller
         args:
+        - --cm-namespace=$(POD_NAMESPACE)
         image: controller:latest
         name: flowcontroller
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/internal/controller/flow_controller_test.go
+++ b/internal/controller/flow_controller_test.go
@@ -61,17 +61,19 @@ var _ = Describe("Pod Controller", func() {
 	}
 
 	BeforeEach(func() {
+		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-ns-"}}
+		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
 		ctrl = gomock.NewController(GinkgoT())
 		execMock = exec.NewMockAPI(ctrl)
 
 		flowController = &FlowReconciler{
-			NodeName: "host1",
-			Client:   k8sClient,
-			Exec:     execMock,
+			NodeName:           "host1",
+			ConfigMapNamespace: ns.Name,
+			ConfigMapName:      "config",
+			Client:             k8sClient,
+			Exec:               execMock,
 		}
-
-		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-ns-"}}
-		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 		// default pod config
 		pod = &corev1.Pod{
@@ -93,6 +95,7 @@ var _ = Describe("Pod Controller", func() {
 	})
 
 	AfterEach(func() {
+		ctrl.Finish()
 		Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
 	})
 

--- a/internal/controller/hostconfig_controller.go
+++ b/internal/controller/hostconfig_controller.go
@@ -1,0 +1,130 @@
+/*
+ Copyright 2025, NVIDIA CORPORATION & AFFILIATES
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Mellanox/spectrum-x-operator/pkg/config"
+	"github.com/Mellanox/spectrum-x-operator/pkg/exec"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
+
+type HostConfigReconciler struct {
+	client.Client
+	NodeName           string
+	ConfigMapNamespace string
+	ConfigMapName      string
+	Exec               exec.API
+}
+
+func (r *HostConfigReconciler) Reconcile(ctx context.Context, conf *corev1.ConfigMap) (ctrl.Result, error) {
+	logr := log.FromContext(ctx)
+
+	logr.Info("reconcile", "namespace", conf.Namespace, "name", conf.Name)
+
+	cfg, err := config.ParseConfig(conf.Data["config"])
+	if err != nil {
+		logr.Error(err, "failed to parse config")
+		// will reconcile again if config map is updated
+		return reconcile.Result{}, nil
+	}
+
+	var host *config.Host
+	for _, h := range cfg.Hosts {
+		if h.HostID == r.NodeName {
+			host = &h
+			break
+		}
+	}
+
+	if host == nil {
+		logr.Info("host not found", "node", r.NodeName)
+		// will reconcile again if config map is updated
+		return reconcile.Result{}, nil
+	}
+
+	for _, rail := range host.Rails {
+		bridge, err := getBridgeToRail(&rail, cfg, r.Exec)
+		if err != nil {
+			logr.Error(err, "failed to get bridge to rail", "rail", rail)
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
+		pf, err := getRailDevice(rail.Name, cfg)
+		if err != nil {
+			logr.Error(err, "failed to get rail device", "rail", rail)
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
+		if err := r.addArpFlows(bridge, pf); err != nil {
+			logr.Error(err, "failed to add arp flows", "rail", rail)
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *HostConfigReconciler) addArpFlows(bridge string, pf string) error {
+	// TODO: check if there are multiple ip addresses on the port, otherwise the function will fail
+	localIP, err := r.Exec.ExecutePrivileged(fmt.Sprintf(`ip -o -4 addr show %s |  awk '{print $4}' | cut -d'/' -f1`,
+		bridge))
+	if err != nil {
+		return err
+	}
+
+	// ovs-ofctl add-flow br-0000_08_00.0 "table=0,priority=100,arp,arp_tpa=3.0.0.2,actions=output:local"
+	// ovs-ofctl add-flow br-0000_08_00.0 "table=0,priority=100,arp,arp_spa=3.0.0.2,actions=output:eth2"
+	flow := fmt.Sprintf(`ovs-ofctl add-flow %s "table=0,priority=100,arp,arp_tpa=%s,actions=output:local"`,
+		bridge, localIP)
+	if _, err := r.Exec.Execute(flow); err != nil {
+		return fmt.Errorf("failed to exec [%s]: %s", flow, err)
+	}
+
+	flow = fmt.Sprintf(`ovs-ofctl add-flow %s "table=0,priority=100,arp,arp_spa=%s,actions=output:%s"`,
+		bridge, localIP, pf)
+	if _, err := r.Exec.Execute(flow); err != nil {
+		return fmt.Errorf("failed to exec [%s]: %s", flow, err)
+	}
+
+	return nil
+}
+
+func (r *HostConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			cm, ok := object.(*corev1.ConfigMap)
+			if !ok {
+				return true
+			}
+			return cm.Name == r.ConfigMapName &&
+				cm.Namespace == r.ConfigMapNamespace
+		})).
+		Complete(reconcile.AsReconciler(r.Client, r))
+}

--- a/internal/controller/hostconfig_controller_test.go
+++ b/internal/controller/hostconfig_controller_test.go
@@ -1,0 +1,80 @@
+/*
+ Copyright 2025, NVIDIA CORPORATION & AFFILIATES
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"github.com/Mellanox/spectrum-x-operator/pkg/exec"
+	gomock "github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("HostConfig Controller", func() {
+	var (
+		hostConfigController *HostConfigReconciler
+		nodeName             = "host1"
+		ctx                  = context.Background()
+		ns                   *corev1.Namespace
+		execMock             *exec.MockAPI
+		ctrl                 *gomock.Controller
+		cm                   *corev1.ConfigMap
+	)
+
+	BeforeEach(func() {
+		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-ns-"}}
+		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+		ctrl = gomock.NewController(GinkgoT())
+		execMock = exec.NewMockAPI(ctrl)
+
+		hostConfigController = &HostConfigReconciler{
+			Client:             k8sClient,
+			NodeName:           nodeName,
+			ConfigMapNamespace: ns.Name,
+			ConfigMapName:      "config",
+			Exec:               execMock,
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+		Expect(k8sClient.Delete(ctx, cm)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+	})
+
+	It("invalid configmap", func() {
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "config",
+				Namespace: ns.Name,
+			},
+			Data: map[string]string{
+				"foo": `bar`,
+			},
+		}
+		Expect(k8sClient.Create(ctx, cm)).Should(Succeed())
+
+		res, err := hostConfigController.Reconcile(ctx, cm)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(res.RequeueAfter).Should(BeZero())
+	})
+
+})

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -95,13 +94,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	configNS := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: topologyConfigMap.Namespace,
-		},
-	}
-
-	Expect(k8sClient.Create(context.Background(), configNS)).Should(Succeed())
 	By("setting up and running the test reconciler")
 	testManager, err := ctrl.NewManager(cfg,
 		ctrl.Options{


### PR DESCRIPTION
host config controller - will define flows between local port and TOR, those flows are used only for debug flow controller - adding flows related to pod to TOR flows

In the deployment get the configuraiton name and namespace as a parameter