### PR TITLE
bug: inverse p2p IP addresses

### DIFF
--- a/internal/controller/ipam_controller_test.go
+++ b/internal/controller/ipam_controller_test.go
@@ -174,12 +174,12 @@ func rail1ExpectedSpec() nvipamv1.CIDRPoolSpec {
 		StaticAllocations: []nvipamv1.CIDRPoolStaticAllocation{
 			{
 				NodeName: "host-1",
-				Gateway:  "192.0.0.0",
+				Gateway:  "192.0.0.1",
 				Prefix:   "192.0.0.0/31",
 			},
 			{
 				NodeName: "host-2",
-				Gateway:  "192.0.0.2",
+				Gateway:  "192.0.0.3",
 				Prefix:   "192.0.0.2/31",
 			},
 		},
@@ -198,12 +198,12 @@ func rail2ExpectedSpec() nvipamv1.CIDRPoolSpec {
 		StaticAllocations: []nvipamv1.CIDRPoolStaticAllocation{
 			{
 				NodeName: "host-1",
-				Gateway:  "192.32.0.0",
+				Gateway:  "192.32.0.1",
 				Prefix:   "192.32.0.0/31",
 			},
 			{
 				NodeName: "host-2",
-				Gateway:  "192.32.0.2",
+				Gateway:  "192.32.0.3",
 				Prefix:   "192.32.0.2/31",
 			},
 		},


### PR DESCRIPTION
test pod:
```
[root@test-pod-rail-1 /]# ip -br a
lo               UNKNOWN        127.0.0.1/8 ::1/128 
eth0@if156       UP             10.244.0.123/24 fe80::f0c4:7cff:fec4:1621/64 
net1             UP             192.0.0.0/31 fe80::a473:2dff:fe18:d6ff/64 
[root@test-pod-rail-1 /]# 
[root@test-pod-rail-1 /]# ip r
default via 10.244.0.1 dev eth0 
10.244.0.0/24 dev eth0 proto kernel scope link src 10.244.0.123 
10.244.0.0/16 via 10.244.0.1 dev eth0 
192.0.0.0/31 dev net1 proto kernel scope link src 192.0.0.0 
192.0.0.0/11 via 192.0.0.1 dev net1 
192.0.0.0/8 via 192.0.0.1 dev net1 
```

CIDRPool:
```
apiVersion: nv-ipam.nvidia.com/v1alpha1
kind: CIDRPool
metadata:
  creationTimestamp: "2025-03-05T13:12:43Z"
  generation: 2
  labels:
    spectrumxipamcontroller: ""
  name: rail-1
  namespace: nvidia-network-operator
  resourceVersion: "13134433"
  uid: 8d790769-973d-4b60-ac7a-4adc1c17702f
spec:
  cidr: 192.0.0.0/11
  gatewayIndex: 0
  perNodeNetworkPrefix: 31
  routes:
  - dst: 192.0.0.0/11
  - dst: 192.0.0.0/8
  staticAllocations:
  - gateway: 192.0.0.1
    nodeName: cloud-dev-10
    prefix: 192.0.0.0/31
  - gateway: 192.0.0.3
    nodeName: cloud-dev-11
    prefix: 192.0.0.2/31
status:
  allocations:
  - gateway: 192.0.0.1
    nodeName: cloud-dev-10
    prefix: 192.0.0.0/31
  - gateway: 192.0.0.3
    nodeName: cloud-dev-11
    prefix: 192.0.0.2/31
  - gateway: 192.0.0.4
    nodeName: cloud-dev-70
    prefix: 192.0.0.4/31
```