### PR TITLE
chore: add gw IP before rail

### DIFF
--- a/internal/controller/ovs_ipaddress_controller.go
+++ b/internal/controller/ovs_ipaddress_controller.go
@@ -120,22 +120,6 @@ func (r *OvsIPaddressReconciler) processRailDeviceMapping(ctx context.Context, m
 		return fmt.Errorf("failed to set OVS internal interface state up %s: %w", bridgeInternalIfc, err)
 	}
 
-	// Get the IP and subnet from railDevice
-	railAddrs, err := r.getIPsFromInterface(railDevice)
-	if err != nil {
-		return fmt.Errorf("failed to get IP from rail %s, device %s: %w", rail, railDevice, err)
-	}
-
-	if len(railAddrs) == 0 {
-		logr.Info("No IP found on rail device", "rail", rail, "dev", railDevice)
-		return nil
-	}
-
-	// Extract the full CIDR (IP + subnet mask)
-	railCIDR := railAddrs[0].String()
-	railIP := railAddrs[0].IP.String()
-	logr.Info("Rail IP with subnet", "rail", rail, "dev", railDevice, "CIDR", railCIDR)
-
 	// Get all IPs from bridge interface
 	bridgeAddrs, err := r.getIPsFromInterface(bridgeInternalIfc)
 	if err != nil {
@@ -156,6 +140,22 @@ func (r *OvsIPaddressReconciler) processRailDeviceMapping(ctx context.Context, m
 			return fmt.Errorf("failed to add gateway IP %s to OVS bridge interface %s: %w", gwCIDR, bridgeInternalIfc, err)
 		}
 	}
+
+	// Get the IP and subnet from railDevice
+	railAddrs, err := r.getIPsFromInterface(railDevice)
+	if err != nil {
+		return fmt.Errorf("failed to get IP from rail %s, device %s: %w", rail, railDevice, err)
+	}
+
+	if len(railAddrs) == 0 {
+		logr.Info("No IP found on rail device", "rail", rail, "dev", railDevice)
+		return nil
+	}
+
+	// Extract the full CIDR (IP + subnet mask)
+	railCIDR := railAddrs[0].String()
+	railIP := railAddrs[0].IP.String()
+	logr.Info("Rail IP with subnet", "rail", rail, "dev", railDevice, "CIDR", railCIDR)
 
 	// Ensure the bridge has the rail IP (with subnet) and move it from railDevice if needed
 	if _, exists := bridgeIPSet[railIP]; !exists {

--- a/internal/controller/ovs_ipaddress_controller_test.go
+++ b/internal/controller/ovs_ipaddress_controller_test.go
@@ -107,13 +107,13 @@ var _ = Describe("OvsIPaddressReconciler", func() {
 			mockNetlink.EXPECT().LinkByName("br-0000_08_00.1").Return(internalLink1, nil).AnyTimes()
 			mockNetlink.EXPECT().IsLinkAdminStateUp(internalLink1).Return(false)
 			mockNetlink.EXPECT().LinkSetUp(internalLink1).Return(nil)
+			mockNetlink.EXPECT().IPv4Addresses(internalLink1).Return([]netlink.Addr{}, nil)
+			mockNetlink.EXPECT().AddrAdd(internalLink1, "192.0.0.1/31").Return(nil)
 			eth0Link := &netlink.Dummy{}
 			mockNetlink.EXPECT().LinkByName("eth0").Return(eth0Link, nil).AnyTimes()
 			mockNetlink.EXPECT().IPv4Addresses(eth0Link).Return([]netlink.Addr{
 				{IPNet: &net.IPNet{IP: net.ParseIP("172.0.0.2"), Mask: net.CIDRMask(24, 32)}},
 			}, nil)
-			mockNetlink.EXPECT().IPv4Addresses(internalLink1).Return([]netlink.Addr{}, nil)
-			mockNetlink.EXPECT().AddrAdd(internalLink1, "192.0.0.1/31").Return(nil)
 			mockNetlink.EXPECT().AddrAdd(internalLink1, "172.0.0.2/24").Return(nil)
 			mockNetlink.EXPECT().AddrDel(eth0Link, "172.0.0.2/24").Return(nil)
 			// Port 2
@@ -122,13 +122,13 @@ var _ = Describe("OvsIPaddressReconciler", func() {
 			mockNetlink.EXPECT().LinkByName("br-0000_08_00.2").Return(internalLink2, nil).AnyTimes()
 			mockNetlink.EXPECT().IsLinkAdminStateUp(internalLink2).Return(false)
 			mockNetlink.EXPECT().LinkSetUp(internalLink2).Return(nil)
+			mockNetlink.EXPECT().IPv4Addresses(internalLink2).Return([]netlink.Addr{}, nil)
+			mockNetlink.EXPECT().AddrAdd(internalLink2, "192.32.0.1/31").Return(nil)
 			eth1Link := &netlink.Dummy{}
 			mockNetlink.EXPECT().LinkByName("eth1").Return(eth1Link, nil).AnyTimes()
 			mockNetlink.EXPECT().IPv4Addresses(eth1Link).Return([]netlink.Addr{
 				{IPNet: &net.IPNet{IP: net.ParseIP("172.32.0.2"), Mask: net.CIDRMask(24, 32)}},
 			}, nil)
-			mockNetlink.EXPECT().IPv4Addresses(internalLink2).Return([]netlink.Addr{}, nil)
-			mockNetlink.EXPECT().AddrAdd(internalLink2, "192.32.0.1/31").Return(nil)
 			mockNetlink.EXPECT().AddrAdd(internalLink2, "172.32.0.2/24").Return(nil)
 			mockNetlink.EXPECT().AddrDel(eth1Link, "172.32.0.2/24").Return(nil)
 			result, err := r.Reconcile(ctx, request)


### PR DESCRIPTION
In case the physical port does not have an IP,
make sure to assign the GW IP to the internal interface anyway.