### PR TITLE
fix mac build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/gomega v1.36.3
 	github.com/vishvananda/netlink v1.3.0
 	go.uber.org/multierr v1.11.0
+	golang.org/x/sys v0.31.0
 	k8s.io/api v0.32.3
 	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3
@@ -81,7 +82,6 @@ require (
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/term v0.30.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.7.0 // indirect

--- a/pkg/lib/netlink/netlink.go
+++ b/pkg/lib/netlink/netlink.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 func New() NetlinkLib {
@@ -56,7 +57,7 @@ func (w *libWrapper) IsLinkAdminStateUp(link Link) bool {
 
 // IPv4Adresses return the IPv4 addresses of a link
 func (w *libWrapper) IPv4Addresses(link Link) ([]netlink.Addr, error) {
-	return netlink.AddrList(link, netlink.FAMILY_V4)
+	return netlink.AddrList(link, unix.AF_INET)
 }
 
 // AddrDel delete an IP address from a link
@@ -94,5 +95,5 @@ func (w *libWrapper) GetRouteSrc(dst string) (string, error) {
 }
 
 func (w *libWrapper) NeighList(linkIndex int) ([]netlink.Neigh, error) {
-	return netlink.NeighList(linkIndex, netlink.FAMILY_V4)
+	return netlink.NeighList(linkIndex, unix.AF_INET)
 }


### PR DESCRIPTION
netlink does not exist in mac systems
meaning that mac users will get an error when trying to build or run tests to avoid that we can use unix.AF_INET instread of netlink family Looking at netlink code the original definition is the same