### PR TITLE
Use POD_NAMESPACE for SR-IOV objects

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,7 +52,7 @@ spec:
           - --health-probe-bind-address=:8081
           - --cm-namespace=$(POD_NAMESPACE)
           - --cidrpools-namespace=$(POD_NAMESPACE)
-          - --sriov-obj-namespace=$(SRIOV_NAMESPACE)
+          - --sriov-obj-namespace=$(POD_NAMESPACE)
         env:
           - name: POD_NAMESPACE
             valueFrom:


### PR DESCRIPTION
Let's use the same namespace for all objects we use to simplify default deployments.