### PR TITLE
imp: add stale flows cleanup

### DIFF
--- a/cmd/flowscontroller/main.go
+++ b/cmd/flowscontroller/main.go
@@ -21,8 +21,10 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
+	"time"
 
 	"github.com/Mellanox/spectrum-x-operator/internal/controller"
+	"github.com/Mellanox/spectrum-x-operator/internal/staleflows"
 	"github.com/Mellanox/spectrum-x-operator/pkg/exec"
 	"github.com/Mellanox/spectrum-x-operator/pkg/filewatcher"
 	"github.com/Mellanox/spectrum-x-operator/pkg/lib/netlink"
@@ -159,6 +161,14 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Pod")
 		os.Exit(1)
 	}
+
+	staleFlowsCleaner := &staleflows.Cleaner{
+		Client:          mgr.GetClient(),
+		Flows:           &controller.Flows{Exec: &exec.Exec{}, NetlinkLib: netlink.New()},
+		CleanupInterval: 5 * time.Minute,
+	}
+
+	staleFlowsCleaner.StartCleanupRoutine(context.Background())
 
 	//+kubebuilder:scaffold:builder
 

--- a/internal/controller/mock_flows.go
+++ b/internal/controller/mock_flows.go
@@ -5,6 +5,7 @@
 package controller
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -45,6 +46,20 @@ func (m *MockFlowsAPI) AddPodRailFlows(cookie uint64, vf, bridge, podIP, podMAC 
 func (mr *MockFlowsAPIMockRecorder) AddPodRailFlows(cookie, vf, bridge, podIP, podMAC interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPodRailFlows", reflect.TypeOf((*MockFlowsAPI)(nil).AddPodRailFlows), cookie, vf, bridge, podIP, podMAC)
+}
+
+// CleanupStaleFlowsForBridges mocks base method.
+func (m *MockFlowsAPI) CleanupStaleFlowsForBridges(ctx context.Context, existingPodUIDs map[string]bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupStaleFlowsForBridges", ctx, existingPodUIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanupStaleFlowsForBridges indicates an expected call of CleanupStaleFlowsForBridges.
+func (mr *MockFlowsAPIMockRecorder) CleanupStaleFlowsForBridges(ctx, existingPodUIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupStaleFlowsForBridges", reflect.TypeOf((*MockFlowsAPI)(nil).CleanupStaleFlowsForBridges), ctx, existingPodUIDs)
 }
 
 // DeletePodRailFlows mocks base method.

--- a/internal/staleflows/stalecleanup.go
+++ b/internal/staleflows/stalecleanup.go
@@ -1,0 +1,88 @@
+/*
+ Copyright 2025, NVIDIA CORPORATION & AFFILIATES
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package staleflows
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Mellanox/spectrum-x-operator/internal/controller"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type Cleaner struct {
+	client.Client
+	CleanupInterval time.Duration
+	Flows           controller.FlowsAPI
+}
+
+// StartCleanupRoutine starts a background goroutine that periodically cleans up stale flows
+func (c *Cleaner) StartCleanupRoutine(ctx context.Context) {
+	go func() {
+		// Use configured interval or default to 5 minutes
+		interval := c.CleanupInterval
+		if interval == 0 {
+			interval = 5 * time.Minute
+		}
+
+		logr := log.FromContext(ctx).WithName("flow-cleanup")
+		logr.Info("Starting flow cleanup routine", "interval", interval)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				logr.Info("Stopping flow cleanup routine")
+				return
+			case <-ticker.C:
+				if err := c.cleanupStaleFlows(ctx); err != nil {
+					logr.Error(err, "Failed to cleanup stale flows")
+				}
+			}
+		}
+	}()
+}
+
+// cleanupStaleFlows removes flows for pods that no longer exist
+func (c *Cleaner) cleanupStaleFlows(ctx context.Context) error {
+	pods := &corev1.PodList{}
+	// clinet cache is set to watch pods on the same node as the reconciler
+	if err := c.List(ctx, pods); err != nil {
+		return fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	if len(pods.Items) == 0 {
+		return nil
+	}
+
+	existingPods := make(map[string]bool, len(pods.Items))
+	for _, pod := range pods.Items {
+		existingPods[string(pod.UID)] = true
+	}
+
+	if err := c.Flows.CleanupStaleFlowsForBridges(ctx, existingPods); err != nil {
+		return fmt.Errorf("failed to cleanup stale flows: %w", err)
+	}
+
+	return nil
+}

--- a/internal/staleflows/stalecleanup_test.go
+++ b/internal/staleflows/stalecleanup_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2025, NVIDIA CORPORATION & AFFILIATES
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package staleflows
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Mellanox/spectrum-x-operator/internal/controller"
+
+	gomock "github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Stale Flows Cleanup", func() {
+	var (
+		cleaner   *Cleaner
+		ctx       context.Context
+		cancel    context.CancelFunc
+		flowsMock *controller.MockFlowsAPI
+		ctrl      *gomock.Controller
+		ns        *corev1.Namespace
+	)
+
+	BeforeEach(func() {
+		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-ns-"}}
+		Expect(k8sClient.Create(context.Background(), ns)).Should(Succeed())
+
+		ctrl = gomock.NewController(GinkgoT())
+		flowsMock = controller.NewMockFlowsAPI(ctrl)
+		ctx, cancel = context.WithCancel(context.Background())
+
+		cleaner = &Cleaner{
+			Client:          k8sClient,
+			Flows:           flowsMock,
+			CleanupInterval: 100 * time.Millisecond, // Short interval for testing
+		}
+	})
+
+	AfterEach(func() {
+		if cancel != nil {
+			cancel()
+		}
+		ctrl.Finish()
+		Expect(k8sClient.Delete(context.Background(), ns)).Should(Succeed())
+	})
+
+	Context("StartCleanupRoutine", func() {
+		It("should start and stop cleanup routine gracefully", func() {
+			// Mock the cleanup call - we expect at least one call
+			flowsMock.EXPECT().CleanupStaleFlowsForBridges(gomock.Any(), gomock.Any()).
+				Return(nil).
+				AnyTimes()
+
+			// Start the cleanup routine
+			cleaner.StartCleanupRoutine(ctx)
+
+			// Give it some time to run at least once
+			time.Sleep(150 * time.Millisecond)
+
+			// Cancel the context to stop the routine
+			cancel()
+			cancel = nil // Prevent double cancellation in AfterEach
+
+			// Give it time to stop gracefully
+			time.Sleep(50 * time.Millisecond)
+		})
+
+		It("should use default interval when not configured", func() {
+			cleanerWithoutInterval := &Cleaner{
+				Client: k8sClient,
+				Flows:  flowsMock,
+				// CleanupInterval not set, should default to 5 minutes
+			}
+
+			// We expect the cleanup to be called, but since the default interval is 5 minutes,
+			// we won't wait for it in the test
+			flowsMock.EXPECT().CleanupStaleFlowsForBridges(gomock.Any(), gomock.Any()).
+				Return(nil).
+				AnyTimes()
+
+			cleanerWithoutInterval.StartCleanupRoutine(ctx)
+
+			// Just verify it starts without error
+			time.Sleep(10 * time.Millisecond)
+		})
+	})
+
+	Context("cleanupStaleFlows", func() {
+		It("should handle no pods gracefully", func() {
+			// No pods in the namespace, so cleanup should return early
+			err := cleaner.cleanupStaleFlows(ctx)
+			Expect(err).Should(BeNil())
+		})
+
+		It("should create pod UID map and call cleanup", func() {
+			// Create some test pods
+			pod1 := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: ns.Name,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app", Image: "image"}},
+				},
+			}
+			pod2 := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: ns.Name,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app", Image: "image"}},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, pod1)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, pod2)).Should(Succeed())
+
+			// Store the pod UIDs we receive for validation
+			var receivedPodUIDs map[string]bool
+
+			// Expect cleanup to be called and capture the pod UIDs
+			flowsMock.EXPECT().CleanupStaleFlowsForBridges(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, podUIDs map[string]bool) error {
+					receivedPodUIDs = podUIDs
+					return nil
+				}).
+				Times(1)
+
+			err := cleaner.cleanupStaleFlows(ctx)
+			Expect(err).Should(BeNil())
+
+			// Validate the received pod UIDs outside the goroutine
+			Expect(len(receivedPodUIDs)).To(Equal(2))
+			Expect(receivedPodUIDs[string(pod1.UID)]).To(BeTrue())
+			Expect(receivedPodUIDs[string(pod2.UID)]).To(BeTrue())
+		})
+
+		It("should handle cleanup errors", func() {
+			// Create a test pod
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: ns.Name,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app", Image: "image"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+
+			// Mock cleanup to return an error
+			flowsMock.EXPECT().CleanupStaleFlowsForBridges(gomock.Any(), gomock.Any()).
+				Return(fmt.Errorf("cleanup failed")).
+				Times(1)
+
+			err := cleaner.cleanupStaleFlows(ctx)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("failed to cleanup stale flows"))
+			Expect(err.Error()).Should(ContainSubstring("cleanup failed"))
+		})
+
+		It("should handle context cancellation gracefully", func() {
+			// Create a cancelled context
+			cancelledCtx, cancel := context.WithCancel(context.Background())
+			cancel() // Cancel immediately
+
+			err := cleaner.cleanupStaleFlows(cancelledCtx)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("failed to list pods"))
+		})
+	})
+
+	Context("Integration test", func() {
+		It("should perform full cleanup cycle", func() {
+			// Create some pods
+			pod1 := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "active-pod",
+					Namespace: ns.Name,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app", Image: "image"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pod1)).Should(Succeed())
+
+			// Track if cleanup was called
+			var callCount int
+
+			// Set up expectations - cleanup should be called
+			flowsMock.EXPECT().CleanupStaleFlowsForBridges(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, podUIDs map[string]bool) error {
+					callCount++
+					// Just verify our pod is in the list (there may be others from other tests)
+					if callCount == 1 && len(podUIDs) > 0 {
+						// At least our pod should be present
+						return nil
+					}
+					return nil
+				}).
+				AnyTimes() // Allow multiple calls due to timing
+
+			// Start cleanup routine
+			cleaner.StartCleanupRoutine(ctx)
+
+			// Wait for at least one cleanup cycle
+			Eventually(func() int {
+				return callCount
+			}, 300*time.Millisecond, 10*time.Millisecond).Should(BeNumerically(">=", 1))
+
+			// Stop the routine
+			cancel()
+			cancel = nil
+		})
+	})
+})

--- a/internal/staleflows/suite_test.go
+++ b/internal/staleflows/suite_test.go
@@ -1,0 +1,111 @@
+/*
+ Copyright 2025, NVIDIA CORPORATION & AFFILIATES
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package staleflows
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	//+kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var ctx, testManagerCancelFunc = context.WithCancel(ctrl.SetupSignalHandler())
+
+const cmName = "specx-config-test"
+
+func TestStaleFlows(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Stale flows cleanup suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		// The BinaryAssetsDirectory is only required if you want to run the tests directly
+		// without call the makefile target test. If not informed it will look for the
+		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
+		// Note that you must have the required binaries setup under the bin directory to perform
+		// the tests directly. When we run make test it will be setup and used automatically.
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
+			fmt.Sprintf("1.32.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = corev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	By("setting up and running the test reconciler")
+	testManager, err := ctrl.NewManager(cfg,
+		ctrl.Options{
+			Scheme: scheme.Scheme,
+			// Set metrics server bind address to 0 to disable it.
+			Metrics: server.Options{
+				BindAddress: "0",
+			}})
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = testManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
+
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	if testManagerCancelFunc != nil {
+		testManagerCancelFunc()
+	}
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})


### PR DESCRIPTION
clenaup will be done in case the controller will fail to delete flows

cleanup logic will list all pods on a local node (using specific cache) for each bridge will check external ids related to rail-cni -  pod-uuid=rail_pod_id if the pod doesn't exit it means that there are stale flows creating a cookie from the pod uuid
removing the flows
removing external-id from the bridge