### PR TITLE
feat: add FilterNICs and use it in createXPlaneBridges

### DIFF
--- a/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
+++ b/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
@@ -182,6 +182,14 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) doReconcile(ctx context.Con
 		return fmt.Errorf("expected one or more rail topologies to be specified")
 	}
 
+	ownerLabels := map[string]string{labelOwnerName: rpc.Name}
+	poolConfig := r.generateSRIOVNetworkPoolConfig(rpc)
+	poolConfig.SetGroupVersionKind(sriovv1.GroupVersion.WithKind(sriovNetworkPoolConfig))
+	poolConfig.Labels = ownerLabels
+	if err := r.Patch(ctx, poolConfig, client.Apply, client.ForceOwnership, client.FieldOwner(SpectrumXRailPoolConfigControllerName)); err != nil {
+		return fmt.Errorf("error while patching %s %s: %w", poolConfig.GetObjectKind().GroupVersionKind().String(), client.ObjectKeyFromObject(poolConfig), err)
+	}
+
 	for _, rt := range rpc.Spec.RailTopology {
 		err := r.reconcileRailTopology(ctx, rpc, rt)
 		if err != nil {
@@ -212,13 +220,6 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) reconcileRailTopology(ctx c
 
 	ownerLabels := map[string]string{labelOwnerName: rpc.Name}
 
-	poolConfig := r.generateSRIOVNetworkPoolConfig(spec, &rt, namespace)
-	poolConfig.SetGroupVersionKind(sriovv1.GroupVersion.WithKind(sriovNetworkPoolConfig))
-	poolConfig.Labels = ownerLabels
-	if err := r.Patch(ctx, poolConfig, client.Apply, client.ForceOwnership, client.FieldOwner(SpectrumXRailPoolConfigControllerName)); err != nil {
-		return fmt.Errorf("error while patching %s %s: %w", poolConfig.GetObjectKind().GroupVersionKind().String(), client.ObjectKeyFromObject(poolConfig), err)
-	}
-
 	var policy *sriovv1.SriovNetworkNodePolicy
 	if len(rt.NicSelector.PfNames) == 1 {
 		// sw plb or no multiplane
@@ -226,9 +227,6 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) reconcileRailTopology(ctx c
 	} else {
 		// hw multiplane
 		policy = r.generateSRIOVNetworkNodePolicy(spec, &rt, true, namespace)
-		if err := r.configureXPlane(ctx, rpc, spec, &rt, namespace); err != nil {
-			return fmt.Errorf("failed to configure xplane for rail topology %s: %w", rt.Name, err)
-		}
 	}
 	policy.Labels = ownerLabels
 
@@ -242,6 +240,12 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) reconcileRailTopology(ctx c
 	ovsNetwork.Labels = ownerLabels
 	if err := r.Patch(ctx, ovsNetwork, client.Apply, client.ForceOwnership, client.FieldOwner(SpectrumXRailPoolConfigControllerName)); err != nil {
 		return fmt.Errorf("error while patching %s %s: %w", ovsNetwork.GetObjectKind().GroupVersionKind().String(), client.ObjectKeyFromObject(ovsNetwork), err)
+	}
+
+	if len(rt.NicSelector.PfNames) > 1 {
+		if err := r.configureXPlane(ctx, rpc, spec, &rt, namespace); err != nil {
+			return fmt.Errorf("failed to configure xplane for rail topology %s: %w", rt.Name, err)
+		}
 	}
 
 	return nil
@@ -621,15 +625,15 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) patchSyncStatus(ctx context
 	return r.Status().Patch(ctx, rpc, patch)
 }
 
-func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateSRIOVNetworkPoolConfig(spec *v1alpha1.SpectrumXRailPoolConfigSpec, rt *v1alpha1.RailTopology, namespace string) *sriovv1.SriovNetworkPoolConfig {
+func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateSRIOVNetworkPoolConfig(rpc *v1alpha1.SpectrumXRailPoolConfig) *sriovv1.SriovNetworkPoolConfig {
 	nodeSelector := &metav1.LabelSelector{
-		MatchLabels: spec.NodeSelector,
+		MatchLabels: rpc.Spec.NodeSelector,
 	}
 
 	nodePool := &sriovv1.SriovNetworkPoolConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      rt.Name,
-			Namespace: namespace,
+			Name:      rpc.Name,
+			Namespace: rpc.Namespace,
 		},
 		Spec: sriovv1.SriovNetworkPoolConfigSpec{
 			NodeSelector:             nodeSelector,
@@ -645,11 +649,11 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateSRIOVNetworkPoolCon
 
 func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateSRIOVNetworkNodePolicy(spec *v1alpha1.SpectrumXRailPoolConfigSpec, rt *v1alpha1.RailTopology, hardwarePLB bool, namespace string) *sriovv1.SriovNetworkNodePolicy {
 	nicSelector := &sriovv1.SriovNetworkNicSelector{
-		PfNames: []string{rt.NicSelector.PfNames[0]},
+		PfNames: rt.NicSelector.PfNames,
 	}
 	nodeSelector := spec.NodeSelector
 
-	devlinkParams := []sriovv1.DevlinkParam{{Name: "esw_multiport", Value: "true", Cmode: "cmode", ApplyOn: "PF"}}
+	devlinkParams := []sriovv1.DevlinkParam{{Name: "esw_multiport", Value: "true", Cmode: "runtime", ApplyOn: "PF"}}
 
 	nodePolicy := &sriovv1.SriovNetworkNodePolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -667,7 +671,7 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateSRIOVNetworkNodePol
 			IsRdma:       true,
 			EswitchMode:  "switchdev",
 			DevlinkParams: sriovv1.DevlinkParams{
-				devlinkParams,
+				Params: devlinkParams,
 			},
 		},
 	}

--- a/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
+++ b/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
@@ -154,7 +154,7 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) doReconcile(ctx context.Con
 				log.Error(err, "failed to delete rail topology resources", "rail topology", rt)
 				return err
 			}
-			if err := r.cleanupXPlaneBridges(&rt, !xplaneDeleted); err != nil {
+			if err := r.cleanupXPlaneBridges(ctx, &rt, !xplaneDeleted); err != nil {
 				log.Error(err, "failed to cleanup xplane bridges", "rail topology", rt)
 				return err
 			}
@@ -166,16 +166,11 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) doReconcile(ctx context.Con
 	}
 
 	if rpc.Status.SyncStatus != v1alpha1.SyncStatusInProgress {
-		if rpc.Generation == rpc.Status.ObservedGeneration {
-			// Already reconciled this generation, nothing to do
-			return nil
-		}
 		patch := client.MergeFrom(rpc.DeepCopy())
 		rpc.Status.SyncStatus = v1alpha1.SyncStatusInProgress
 		if err := r.Status().Patch(ctx, rpc, patch); err != nil {
 			return fmt.Errorf("failed to set SyncStatus to InProgress: %w", err)
 		}
-		return nil
 	}
 
 	if len(rpc.Spec.RailTopology) < 1 {
@@ -426,47 +421,24 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) createXPlaneBridges(ctx con
 		ifaceByName[iface.Name] = iface
 	}
 
-	pfNames := lib.FilterNICs(ctx, rt.NicSelector.PfNames)
-
-	// Build desired br-railX bridge configs — one bridge per NIC
-	// Use ConfigureBridges from sriov-network-operator to manage them via OVSDB.
-	desiredBridges := make([]sriovv1.OVSConfigExt, 0, len(pfNames))
-	for idx, pfName := range pfNames {
-		uplink := sriovv1.OVSUplinkConfigExt{
-			Name: pfName,
-			Interface: sriovv1.OVSInterfaceConfig{
-				Type: ovsNetworkInterfaceType,
-			},
-		}
-		if iface, ok := ifaceByName[pfName]; ok {
-			uplink.PciAddress = iface.PciAddress
-			if rt.MTU > 0 {
-				mtu := rt.MTU
-				uplink.Interface.MTURequest = &mtu
-			}
-		}
-		desiredBridges = append(desiredBridges, sriovv1.OVSConfigExt{
-			Name: fmt.Sprintf("br-%s-%d", rt.Name, idx),
-			Bridge: sriovv1.OVSBridgeConfig{
-				DatapathType: ovsDataPathType,
-			},
-			Uplinks: []sriovv1.OVSUplinkConfigExt{uplink},
-		})
-	}
-
-	currentBridges, err := r.bridge.DiscoverBridges()
+	pfNames, err := lib.FilterNICs(ctx, rt.NicSelector.PfNames)
 	if err != nil {
-		return fmt.Errorf("failed to discover bridges: %w", err)
+		return fmt.Errorf("failed to filter NICSs for specified selector: %w", err)
 	}
 
-	if err := r.bridge.ConfigureBridges(
-		sriovv1.Bridges{OVS: desiredBridges},
-		currentBridges,
-	); err != nil {
-		return fmt.Errorf("failed to configure rail bridges: %w", err)
+	// Build desired bridge configs — one bridge per NIC
+	// Use ConfigureBridges from sriov-network-operator to manage them via OVSDB.
+	for idx, pfName := range pfNames {
+		brName := fmt.Sprintf("br-%s-%d", pfName, idx)
+		if _, err := r.exec.Execute(fmt.Sprintf(
+			"ovs-vsctl --may-exist add-br %s -- set bridge %s datapath_type=%s",
+			brName, brName, ovsDataPathType,
+		)); err != nil {
+			return fmt.Errorf("failed to create bridge %s: %w", brName, err)
+		}
 	}
 
-	// Create br-xplane bridge. It connects all br-railX bridges via patch ports and
+	// Create br-xplane bridge. It connects all bridges via patch ports and
 	// has no single physical uplink, so it cannot be created via ConfigureBridges.
 	if _, err := r.exec.Execute(fmt.Sprintf(
 		"ovs-vsctl --may-exist add-br %s -- set bridge %s datapath_type=%s",
@@ -475,38 +447,24 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) createXPlaneBridges(ctx con
 		return fmt.Errorf("failed to create bridge %s: %w", xplaneBridge, err)
 	}
 
-	// Connect br-xplane to each br-railX via patch ports and add VF representors.
+	// Connect br-xplane to each bridge via patch ports and add VF representors.
 	for idx, pfName := range pfNames {
-		railBridge := fmt.Sprintf("br-%s-%d", rt.Name, idx)
-		patchXplanePort := fmt.Sprintf("patch-xplane-to-%s-%d", rt.Name, idx)
-		patchRailPort := fmt.Sprintf("patch-%s-%d-to-xplane", rt.Name, idx)
+		railBridge := fmt.Sprintf("br-%s-%d", pfName, idx)
+		patchXplanePort := fmt.Sprintf("patch-xplane-to-%s-%d", pfName, idx)
+		patchRailPort := fmt.Sprintf("patch-%s-%d-to-xplane", pfName, idx)
 
 		if _, err := r.exec.Execute(fmt.Sprintf(
-			"ovs-vsctl --may-exist add-port %s %s -- set Interface %s type=patch options:peer=%s",
+			"ovs-vsctl --may-exist add-port %s %s -- set interface %s type=patch options:peer=%s",
 			xplaneBridge, patchXplanePort, patchXplanePort, patchRailPort,
 		)); err != nil {
 			return fmt.Errorf("failed to add patch port %s to bridge %s: %w", patchXplanePort, xplaneBridge, err)
 		}
 
 		if _, err := r.exec.Execute(fmt.Sprintf(
-			"ovs-vsctl --may-exist add-port %s %s -- set Interface %s type=patch options:peer=%s",
+			"ovs-vsctl --may-exist add-port %s %s -- set interface %s type=patch options:peer=%s",
 			railBridge, patchRailPort, patchRailPort, patchXplanePort,
 		)); err != nil {
 			return fmt.Errorf("failed to add patch port %s to bridge %s: %w", patchRailPort, railBridge, err)
-		}
-
-		if iface, ok := ifaceByName[pfName]; ok {
-			for _, vf := range iface.VFs {
-				if vf.RepresentorName == "" {
-					continue
-				}
-				if _, err := r.exec.Execute(fmt.Sprintf(
-					"ovs-vsctl --may-exist add-port %s %s",
-					railBridge, vf.RepresentorName,
-				)); err != nil {
-					return fmt.Errorf("failed to add representor %s to bridge %s: %w", vf.RepresentorName, railBridge, err)
-				}
-			}
 		}
 	}
 
@@ -515,9 +473,14 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) createXPlaneBridges(ctx con
 
 // cleanupXPlaneBridges tears down host OVS bridges created by createXPlaneBridges.
 // deleteXplane controls whether br-xplane itself is deleted (only on the last rail topology).
-func (r *SpectrumXRailPoolConfigHostFlowsReconciler) cleanupXPlaneBridges(rt *v1alpha1.RailTopology, deleteXplane bool) error {
-	for idx := range rt.NicSelector.PfNames {
-		railBridge := fmt.Sprintf("br-%s-%d", rt.Name, idx)
+func (r *SpectrumXRailPoolConfigHostFlowsReconciler) cleanupXPlaneBridges(ctx context.Context, rt *v1alpha1.RailTopology, deleteXplane bool) error {
+	pfNames, err := lib.FilterNICs(ctx, rt.NicSelector.PfNames)
+	if err != nil {
+		return fmt.Errorf("failed to filter NICSs for specified selector: %w", err)
+	}
+
+	for idx, pfName := range pfNames {
+		railBridge := fmt.Sprintf("br-%s-%d", pfName, idx)
 		if _, err := r.exec.Execute(fmt.Sprintf(
 			"ovs-vsctl --if-exists del-br %s", railBridge,
 		)); err != nil {
@@ -578,7 +541,7 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) deleteRemovedRailTopologies
 					PfNames: policy.Spec.NicSelector.PfNames,
 				},
 			}
-			if err := r.cleanupXPlaneBridges(&rt, false); err != nil {
+			if err := r.cleanupXPlaneBridges(ctx, &rt, false); err != nil {
 				return fmt.Errorf("failed to cleanup xplane bridges for removed rail topology %s: %w", policy.Name, err)
 			}
 		}
@@ -636,10 +599,16 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateSRIOVNetworkPoolCon
 			Namespace: rpc.Namespace,
 		},
 		Spec: sriovv1.SriovNetworkPoolConfigSpec{
-			NodeSelector:             nodeSelector,
-			RdmaMode:                 "exclusive",
+			NodeSelector: nodeSelector,
+			RdmaMode:     "exclusive",
 			OvsHardwareOffloadConfig: sriovv1.OvsHardwareOffloadConfig{
-				// TODO: otherConfig option
+				Name: "otherConfig",
+				OvsConfig: map[string]string{
+					"doca-init":          "true",
+					"hw-offload":         "true",
+					"hw-offload-ct-size": "0",
+					"max-idle":           "300000",
+				},
 			},
 		},
 	}

--- a/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
+++ b/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
@@ -50,6 +50,7 @@ import (
 	"github.com/Mellanox/spectrum-x-operator/api/v1alpha1"
 	"github.com/Mellanox/spectrum-x-operator/pkg/config"
 	"github.com/Mellanox/spectrum-x-operator/pkg/exec"
+	"github.com/Mellanox/spectrum-x-operator/pkg/lib"
 )
 
 const (
@@ -276,7 +277,7 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) configureXPlane(ctx context
 		return nil
 	}
 
-	err := r.createXPlaneBridges(rt, localNodeState)
+	err := r.createXPlaneBridges(ctx, rt, localNodeState)
 	if err != nil {
 		return fmt.Errorf("failed to create X-Plane bridges: %w", err)
 	}
@@ -413,7 +414,7 @@ func updateDaemonsetNodeSelector(obj *uns.Unstructured, nodeSelector map[string]
 	return nil
 }
 
-func (r *SpectrumXRailPoolConfigHostFlowsReconciler) createXPlaneBridges(rt *v1alpha1.RailTopology, nodeState *sriovv1.SriovNetworkNodeState) error {
+func (r *SpectrumXRailPoolConfigHostFlowsReconciler) createXPlaneBridges(ctx context.Context, rt *v1alpha1.RailTopology, nodeState *sriovv1.SriovNetworkNodeState) error {
 	// Build map of PF name -> interface info from node state
 	ifaceByName := make(map[string]*sriovv1.InterfaceExt, len(nodeState.Status.Interfaces))
 	for i := range nodeState.Status.Interfaces {
@@ -421,10 +422,12 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) createXPlaneBridges(rt *v1a
 		ifaceByName[iface.Name] = iface
 	}
 
-	// Build desired br-railX bridge configs — one bridge per PF with PF as DPDK uplink.
+	pfNames := lib.FilterNICs(ctx, rt.NicSelector.PfNames)
+
+	// Build desired br-railX bridge configs — one bridge per NIC
 	// Use ConfigureBridges from sriov-network-operator to manage them via OVSDB.
-	desiredBridges := make([]sriovv1.OVSConfigExt, 0, len(rt.NicSelector.PfNames))
-	for idx, pfName := range rt.NicSelector.PfNames {
+	desiredBridges := make([]sriovv1.OVSConfigExt, 0, len(pfNames))
+	for idx, pfName := range pfNames {
 		uplink := sriovv1.OVSUplinkConfigExt{
 			Name: pfName,
 			Interface: sriovv1.OVSInterfaceConfig{
@@ -469,7 +472,7 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) createXPlaneBridges(rt *v1a
 	}
 
 	// Connect br-xplane to each br-railX via patch ports and add VF representors.
-	for idx, pfName := range rt.NicSelector.PfNames {
+	for idx, pfName := range pfNames {
 		railBridge := fmt.Sprintf("br-%s-%d", rt.Name, idx)
 		patchXplanePort := fmt.Sprintf("patch-xplane-to-%s-%d", rt.Name, idx)
 		patchRailPort := fmt.Sprintf("patch-%s-%d-to-xplane", rt.Name, idx)
@@ -642,9 +645,11 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateSRIOVNetworkPoolCon
 
 func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateSRIOVNetworkNodePolicy(spec *v1alpha1.SpectrumXRailPoolConfigSpec, rt *v1alpha1.RailTopology, hardwarePLB bool, namespace string) *sriovv1.SriovNetworkNodePolicy {
 	nicSelector := &sriovv1.SriovNetworkNicSelector{
-		PfNames: rt.NicSelector.PfNames,
+		PfNames: []string{rt.NicSelector.PfNames[0]},
 	}
 	nodeSelector := spec.NodeSelector
+
+	devlinkParams := []sriovv1.DevlinkParam{{Name: "esw_multiport", Value: "true", Cmode: "cmode", ApplyOn: "PF"}}
 
 	nodePolicy := &sriovv1.SriovNetworkNodePolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -661,6 +666,9 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateSRIOVNetworkNodePol
 			NodeSelector: nodeSelector,
 			IsRdma:       true,
 			EswitchMode:  "switchdev",
+			DevlinkParams: sriovv1.DevlinkParams{
+				devlinkParams,
+			},
 		},
 	}
 	if !hardwarePLB {

--- a/pkg/lib/pci.go
+++ b/pkg/lib/pci.go
@@ -1,14 +1,32 @@
+/*
+ Copyright 2026, NVIDIA CORPORATION & AFFILIATES
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 package lib
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func FilterNICs(ctx context.Context, pfNames []string) []string {
+func FilterNICs(ctx context.Context, pfNames []string) ([]string, error) {
 	log := log.FromContext(ctx)
 
 	seen := make(map[string]string) // pciSlot -> iface
@@ -29,7 +47,13 @@ func FilterNICs(ctx context.Context, pfNames []string) []string {
 	for _, iface := range seen {
 		result = append(result, iface)
 	}
-	return result
+
+	if len(result) == 0 {
+		return result, fmt.Errorf("expect at least NIC found but got 0")
+	}
+
+	sort.Strings(result)
+	return result, nil
 }
 
 // getPCISlot returns "0000:d8:00" (without function)

--- a/pkg/lib/pci.go
+++ b/pkg/lib/pci.go
@@ -1,0 +1,52 @@
+package lib
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func FilterNICs(ctx context.Context, pfNames []string) []string {
+	log := log.FromContext(ctx)
+
+	seen := make(map[string]string) // pciSlot -> iface
+
+	for _, iface := range pfNames {
+		pciSlot, err := getPCISlot(iface)
+		if err != nil {
+			log.V(0).Info("FilterNICs(): can't get PCI slot for interface, skipping", "interface", iface, "error", err)
+			continue
+		}
+
+		if _, exists := seen[pciSlot]; !exists {
+			seen[pciSlot] = iface
+		}
+	}
+
+	result := make([]string, 0, len(seen))
+	for _, iface := range seen {
+		result = append(result, iface)
+	}
+	return result
+}
+
+// getPCISlot returns "0000:d8:00" (without function)
+func getPCISlot(iface string) (string, error) {
+	link := filepath.Join("/sys/class/net", iface, "device")
+
+	resolved, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		return "", err
+	}
+
+	// Extract last part: 0000:d8:00.0
+	parts := strings.Split(resolved, "/")
+	pciAddr := parts[len(parts)-1]
+
+	// Remove function (.0 / .1)
+	slot := strings.Split(pciAddr, ".")[0]
+
+	return slot, nil
+}


### PR DESCRIPTION
Add pkg/lib/pci.go with FilterNICs which deduplicates PF names by PCI slot. Wire it into createXPlaneBridges (adding ctx parameter) so both bridge-config loops operate on the deduplicated NIC list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NIC filtering by PCI slot to pick one interface per physical slot for bridge attachment.
  * X-Plane bridge setup uses filtered NIC selection and creates bridges/patch ports more reliably.
* **Bug Fixes**
  * SR-IOV pool config is created/owned once per pool to avoid duplication and ownership conflicts.
  * SR-IOV node policy now includes multi-port device parameters and refines X-Plane configuration to run only when multiple PFs are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->