### PR TITLE
ci: fail pulse scans on technical errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,7 +243,8 @@ pulse-scan-oss-operator:
     CONTAINER_IMAGE: $DOCKER_REGISTRY/$OPERATOR_IMAGE_NAME:$UBUNTU_DOCKER_TAG
     NSPECT_ID: $NSPECT_ID
     PROGRAM_VERSION: $NSPECT_RELEASE_VERSION
-  allow_failure: true  # non gating (pipeline stages will display warnings instead of failures)
+  allow_failure:
+    exit_codes: [11, 255]  # non-gating for scan/policy failures; technical errors (e.g. auth, invalid nspect id) still fail the pipeline
 
 pulse-scan-stig-operator:
   stage: pulse-scan-stig
@@ -266,7 +267,8 @@ pulse-scan-stig-operator:
     CONTAINER_IMAGE: $DOCKER_REGISTRY/$OPERATOR_IMAGE_NAME:$UBUNTU_DOCKER_TAG
     NSPECT_ID: $NSPECT_ID
     PROGRAM_VERSION: $NSPECT_RELEASE_VERSION
-  allow_failure: true  # non gating (pipeline stages will display warnings instead of failures)
+  allow_failure:
+    exit_codes: [11, 255]  # non-gating for scan/policy failures; technical errors (e.g. auth, invalid nspect id) still fail the pipeline
 
 pulse-scan-oss-operator-rhel:
   stage: pulse-scan-oss
@@ -286,7 +288,8 @@ pulse-scan-oss-operator-rhel:
     CONTAINER_IMAGE: $DOCKER_REGISTRY/$OPERATOR_IMAGE_NAME:$RHEL_DOCKER_TAG
     NSPECT_ID: $NSPECT_ID
     PROGRAM_VERSION: $NSPECT_RELEASE_VERSION
-  allow_failure: true
+  allow_failure:
+    exit_codes: [11, 255]  # non-gating for scan/policy failures; technical errors (e.g. auth, invalid nspect id) still fail the pipeline
 
 pulse-scan-stig-operator-rhel:
   stage: pulse-scan-stig
@@ -309,4 +312,5 @@ pulse-scan-stig-operator-rhel:
     CONTAINER_IMAGE: $DOCKER_REGISTRY/$OPERATOR_IMAGE_NAME:$RHEL_DOCKER_TAG
     NSPECT_ID: $NSPECT_ID
     PROGRAM_VERSION: $NSPECT_RELEASE_VERSION
-  allow_failure: true
+  allow_failure:
+    exit_codes: [11, 255]  # non-gating for scan/policy failures; technical errors (e.g. auth, invalid nspect id) still fail the pipeline


### PR DESCRIPTION
Replace `allow_failure: true` with `allow_failure: exit_codes: [11, 255]` so scan policy violations remain non-gating (yellow) while technical failures (e.g. sso auth error → exit 1, nspect id not found → exit 2) fail the pipeline (red).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined CI/CD scan validation pipeline to enforce more rigorous error detection and response. The pipeline now properly differentiates between expected scan-related issues that allow pipeline progression and technical failures—such as authentication or configuration errors—that require immediate attention before the deployment and release process continues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->