### PR TITLE
RHEL CVE fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ variables: # additional variables defined at the gitlab group scope
   DOCKER_REGISTRY: nvcr.io/nvstaging/mellanox
   OPERATOR_IMAGE_NAME: spectrum-x-operator-stig-fips
   GOV_READY_POLICY_FILE_PATH: pulse-scan-policies/prodsec_approved_govready_release_policy.json
-  CVE_UPDATES_RHEL: "openssl python3-urllib3"
+  CVE_UPDATES_RHEL: "openssl openssl-libs python3 python3-libs python3-urllib3 glib2 util-linux libnghttp2 vim-minimal libarchive"
 
 # Common job template for building STIG images
 .build-stig-image:


### PR DESCRIPTION
    CVE-2026-27135
    CVE-2026-28421
    CVE-2026-33412
    CVE-2026-34982
    CVE-2026-4424
    CVE-2026-4519
    CVE-2026-4786
    CVE-2026-4878
    CVE-2026-6100
    CVE-2026-28417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced security patching for RHEL-based container builds by expanding the packages included in automated CVE update processes, now covering additional system libraries and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->