### PR TITLE
fix: update stig docker files

### DIFF
--- a/Dockerfile.stig-rhel
+++ b/Dockerfile.stig-rhel
@@ -71,7 +71,6 @@ RUN if [ -n "${CVE_UPDATES_RHEL}" ]; then \
 
 WORKDIR /
 COPY --from=builder /workspace/build/flowcontroller .
-COPY --from=builder /workspace/build/railcni .
 # Copy sources to /src
 COPY --from=builder /workspace /src
 

--- a/Dockerfile.stig-ubuntu
+++ b/Dockerfile.stig-ubuntu
@@ -57,7 +57,6 @@ RUN dpkg --purge collectx || apt-get remove --purge -y collectx || true && \
 
 WORKDIR /
 COPY --from=builder /workspace/build/flowcontroller .
-COPY --from=builder /workspace/build/railcni .
 # Copy sources to /src
 COPY --from=builder /workspace /src
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed `railcni` binary from STIG-hardened container images (RHEL and Ubuntu variants). Container images now include only `flowcontroller` and source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->