### PR TITLE
fix: use netdev datapath type and remove dpdk-lsc-interrupt option

### DIFF
--- a/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
+++ b/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
@@ -64,7 +64,7 @@ const (
 	sriovNodePolicyType     = "SriovNetworkNodePolicy"
 	sriovNetworkPoolConfig  = "SriovNetworkPoolConfig"
 	sriovOVSNetworkType     = "OVSNetwork"
-	ovsDataPathType         = "doca"
+	ovsDataPathType         = "netdev"
 	ovsNetworkInterfaceType = "dpdk"
 )
 
@@ -449,8 +449,7 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) createXPlaneBridges(ctx con
 				" type=doca"+
 				" external_ids:xplane-plane-id=%d"+
 				" external_ids:xplane-group-id=%s"+
-				" external_ids:xplane-uplink=true"+
-				" options:dpdk-lsc-interrupt=true",
+				" external_ids:xplane-uplink=true",
 			xplaneBridge, pfName, pfName, rt.MTU, idx, rt.Name,
 		)); err != nil {
 			log.Error(err, "failed to add uplink patch port to bridge", "PF name", pfName, "bridge name", xplaneBridge)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OVS bridge configuration to use `netdev` data path type instead of `doca`.
  * Removed the DPDK link state change interrupt option from port configurations on `br-xplane`, while maintaining existing uplink identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->