### PR TITLE
fix: set OVS datapath type to netdev

### DIFF
--- a/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
+++ b/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
@@ -64,7 +64,7 @@ const (
 	sriovNodePolicyType     = "SriovNetworkNodePolicy"
 	sriovNetworkPoolConfig  = "SriovNetworkPoolConfig"
 	sriovOVSNetworkType     = "OVSNetwork"
-	ovsDataPathType         = "doca"
+	ovsDataPathType         = "netdev"
 	ovsNetworkInterfaceType = "dpdk"
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure**
  * Updated network packet processing datapath configuration to modify routing and packet handling behavior in the system's network switches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->