### PR TITLE
fix: set OVS datapath type to netdev

### DIFF
--- a/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
+++ b/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
@@ -64,7 +64,7 @@ const (
 	sriovNodePolicyType     = "SriovNetworkNodePolicy"
 	sriovNetworkPoolConfig  = "SriovNetworkPoolConfig"
 	sriovOVSNetworkType     = "OVSNetwork"
-	ovsDataPathType         = "doca"
+	ovsDataPathType         = "netdev"
 	ovsNetworkInterfaceType = "dpdk"
 )
 


### PR DESCRIPTION
(cherry picked from commit b8ebd0008499aa10b238124bdbf2af7e6b2f0040)