### PR TITLE
[fix] Delete a correct instance of SriovNetworkPoolConfig

### DIFF
--- a/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
+++ b/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
@@ -152,10 +152,15 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) doReconcile(ctx context.Con
 			if len(rt.NicSelector.PfNames) > 1 {
 				r.cleanupXPlaneBridges(ctx, &rt)
 			}
+
 			if err := r.deleteRailTopologyResources(ctx, rpc.Namespace, rt.Name); err != nil {
 				log.Error(err, "failed to delete rail topology resources", "rail topology", rt)
 				return err
 			}
+		}
+		poolConfig := &sriovv1.SriovNetworkPoolConfig{ObjectMeta: metav1.ObjectMeta{Name: rpc.Name, Namespace: rpc.Namespace}}
+		if err := r.Delete(ctx, poolConfig); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("failed to delete SriovNetworkPoolConfig %s/%s: %w", rpc.Namespace, rpc.Namespace, err)
 		}
 		patch := client.MergeFrom(rpc.DeepCopy())
 		controllerutil.RemoveFinalizer(rpc, finalizerName)
@@ -505,11 +510,6 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) deleteRailTopologyResources
 		return fmt.Errorf("failed to delete SriovNetworkNodePolicy %s/%s: %w", namespace, rtName, err)
 	}
 
-	poolConfig := &sriovv1.SriovNetworkPoolConfig{ObjectMeta: metav1.ObjectMeta{Name: rtName, Namespace: namespace}}
-	if err := r.Delete(ctx, poolConfig); client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("failed to delete SriovNetworkPoolConfig %s/%s: %w", namespace, rtName, err)
-	}
-
 	ovsNetwork := &sriovv1.OVSNetwork{ObjectMeta: metav1.ObjectMeta{Name: rtName, Namespace: namespace}}
 	if err := r.Delete(ctx, ovsNetwork); client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("failed to delete OVSNetwork %s/%s: %w", namespace, rtName, err)
@@ -547,6 +547,11 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) deleteRemovedRailTopologies
 				return err
 			}
 		}
+	}
+
+	poolConfig := &sriovv1.SriovNetworkPoolConfig{ObjectMeta: metav1.ObjectMeta{Name: rpc.Name, Namespace: rpc.Namespace}}
+	if err := r.Delete(ctx, poolConfig); client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("failed to delete SriovNetworkPoolConfig %s/%s: %w", rpc.Namespace, rpc.Namespace, err)
 	}
 
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced reliability of resource cleanup and deletion processes during configuration management operations to ensure proper cleanup sequence across all topology instances and reduce resource inconsistencies
- Improved system stability and consistency through better management of network configuration resources
- Better handling of bridge cleanup operations during configuration removal procedures to prevent potential resource issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->