### PR TITLE
feat: request hmfs flow steering in generated SriovNetworkNodePolicy

### DIFF
--- a/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
+++ b/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
@@ -625,7 +625,10 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateSRIOVNetworkNodePol
 	}
 	nodeSelector := spec.NodeSelector
 
-	devlinkParams := []sriovv1.DevlinkParam{{Name: "esw_multiport", Value: "true", Cmode: "runtime", ApplyOn: "PF"}}
+	// Spectrum-X requires hardware-managed flow steering (hmfs) on both SW PLB and HW multiplane.
+	// HW multiplane additionally requires multiport e-switch.
+	flowSteeringParam := sriovv1.DevlinkParam{Name: "flow_steering_mode", Value: "hmfs", Cmode: "runtime", ApplyOn: "PF"}
+	eswMultiportParam := sriovv1.DevlinkParam{Name: "esw_multiport", Value: "true", Cmode: "runtime", ApplyOn: "PF"}
 
 	nodePolicy := &sriovv1.SriovNetworkNodePolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -646,9 +649,12 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateSRIOVNetworkNodePol
 	}
 	if hardwarePLB {
 		nodePolicy.Spec.DevlinkParams = sriovv1.DevlinkParams{
-			Params: devlinkParams,
+			Params: []sriovv1.DevlinkParam{eswMultiportParam, flowSteeringParam},
 		}
 	} else {
+		nodePolicy.Spec.DevlinkParams = sriovv1.DevlinkParams{
+			Params: []sriovv1.DevlinkParam{flowSteeringParam},
+		}
 		bridge := &sriovv1.Bridge{
 			GroupingPolicy: "perPF",
 			OVS: &sriovv1.OVSConfig{


### PR DESCRIPTION
Spectrum-X requires hardware-managed flow steering (hmfs) for both SW PLB and HW multiplane (multiport) configurations. Previously the sriov-network-operator hardcoded smfs in configureHWOptionsForSwitchdev, and that operator was changed to honor flow_steering_mode supplied via SriovNetworkNodePolicy.spec.devlinkParams.

Set flow_steering_mode=hmfs in DevlinkParams for both code paths in generateSRIOVNetworkNodePolicy. The HW multiplane path additionally keeps esw_multiport=true; the SW PLB path now also populates DevlinkParams (previously only Bridge was set).


(cherry picked from commit 306ee48cb3eca0b2f1200a8a327d1b8a1504c495)