### PR TITLE
fix: Change hardcoded rdmaQoSTC values to 96

### DIFF
--- a/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
+++ b/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
@@ -82,7 +82,7 @@ const (
 
 const (
 	rdmaQoSToS = 96
-	rdmaQoSTC  = 102
+	rdmaQoSTC  = 96
 )
 
 // SpectrumXRailPoolConfigHostFlowsReconciler reconciles a SpectrumXRailPoolConfig object


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted RDMA Quality of Service configuration for Spectrum-X RDMA device plugins to optimize network performance settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->