### PR TITLE
feat: skip reconciliation when CRD is unchanged and status is Succeeded

### DIFF
--- a/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
+++ b/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
@@ -162,6 +162,11 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) doReconcile(ctx context.Con
 		return r.Patch(ctx, rpc, patch)
 	}
 
+	if rpc.Status.SyncStatus == v1alpha2.SyncStatusSucceeded && rpc.Status.ObservedGeneration == rpc.Generation {
+		log.V(1).Info("CRD is not updated", "currentStatus", rpc.Status.SyncStatus)
+		return nil
+	}
+
 	if rpc.Status.SyncStatus != v1alpha2.SyncStatusInProgress {
 		patch := client.MergeFrom(rpc.DeepCopy())
 		rpc.Status.SyncStatus = v1alpha2.SyncStatusInProgress


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized controller reconciliation logic to skip unnecessary processing when resources are already synchronized, improving efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/spectrum-x-operator/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->