### PR TITLE
feat: add IPv6 VRF meta-plugin support for CIDRPool-based OVSNetworks

### DIFF
--- a/config/openshift/role.yaml
+++ b/config/openshift/role.yaml
@@ -11,3 +11,11 @@ rules:
       - use
     resourceNames:
       - privileged
+  - apiGroups:
+      - nv-ipam.nvidia.com
+    resources:
+      - cidrpools
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -60,6 +60,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - nv-ipam.nvidia.com
+  resources:
+  - cidrpools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - spectrumx.nvidia.com
   resources:
   - spectrumxrailpoolconfigs

--- a/internal/controller/generate_ovs_network_test.go
+++ b/internal/controller/generate_ovs_network_test.go
@@ -1,0 +1,295 @@
+/*
+ Copyright 2025, NVIDIA CORPORATION & AFFILIATES
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/Mellanox/spectrum-x-operator/api/v1alpha2"
+)
+
+var _ = Describe("generateOVSNetwork", func() {
+	const namespace = "test-ns"
+
+	r := &SpectrumXRailPoolConfigHostFlowsReconciler{}
+
+	DescribeTable("MetaPluginsConfig rdma plugin",
+		func(rtName string, addVRF bool) {
+			rt := &v1alpha2.RailTopology{Name: rtName, MTU: 9000}
+			ovs := r.generateOVSNetwork(&v1alpha2.SpectrumXRailPoolConfigSpec{}, rt, false, addVRF, namespace)
+			Expect(ovs.Spec.MetaPluginsConfig).To(ContainSubstring(`"type": "rdma"`))
+			Expect(ovs.Spec.MetaPluginsConfig).To(ContainSubstring(fmt.Sprintf(`"rdmaDeviceName": "rdma_%s"`, rtName)))
+		},
+		Entry("addVRF=false", "rail-1", false),
+		Entry("addVRF=true", "rail-1", true),
+	)
+
+	DescribeTable("VRF meta-plugin",
+		func(addVRF bool, expectVRF bool) {
+			rt := &v1alpha2.RailTopology{Name: "rail-1", MTU: 9000}
+			ovs := r.generateOVSNetwork(&v1alpha2.SpectrumXRailPoolConfigSpec{}, rt, false, addVRF, namespace)
+			if expectVRF {
+				Expect(ovs.Spec.MetaPluginsConfig).To(ContainSubstring(`"type": "vrf"`))
+				Expect(ovs.Spec.MetaPluginsConfig).To(ContainSubstring(`"vrfname": "rail-1"`))
+			} else {
+				Expect(ovs.Spec.MetaPluginsConfig).NotTo(ContainSubstring(`"type": "vrf"`))
+			}
+		},
+		Entry("not added when addVRF is false", false, false),
+		Entry("added when addVRF is true", true, true),
+	)
+
+	It("VRF vrfname matches the rail topology name", func() {
+		rt := &v1alpha2.RailTopology{Name: "my-custom-rail", MTU: 9000}
+		ovs := r.generateOVSNetwork(&v1alpha2.SpectrumXRailPoolConfigSpec{}, rt, false, true, namespace)
+		Expect(ovs.Spec.MetaPluginsConfig).To(ContainSubstring(`"vrfname": "my-custom-rail"`))
+	})
+
+	DescribeTable("bridge field",
+		func(addBridge bool, expectedBridge string) {
+			rt := &v1alpha2.RailTopology{Name: "rail-1", MTU: 9000}
+			ovs := r.generateOVSNetwork(&v1alpha2.SpectrumXRailPoolConfigSpec{}, rt, addBridge, false, namespace)
+			Expect(ovs.Spec.Bridge).To(Equal(expectedBridge))
+		},
+		Entry("bridge set when addBridge=true", true, "br-rail-rail-1"),
+		Entry("bridge empty when addBridge=false", false, ""),
+	)
+
+	DescribeTable("IPAM configuration",
+		func(cidrPoolRef, ipam, expectedIPAM string) {
+			rt := &v1alpha2.RailTopology{Name: "rail-1", MTU: 9000, CidrPoolRef: cidrPoolRef, IPAM: ipam}
+			ovs := r.generateOVSNetwork(&v1alpha2.SpectrumXRailPoolConfigSpec{}, rt, false, false, namespace)
+			Expect(ovs.Spec.IPAM).To(Equal(expectedIPAM))
+		},
+		Entry("empty when neither set", "", "", ""),
+		Entry("cidrpool IPAM from CidrPoolRef", "my-pool", "", `{"type": "nv-ipam","poolName": "my-pool", "poolType": "cidrpool"}`),
+		Entry("custom IPAM from IPAM field", "", `{"type":"custom"}`, `{"type":"custom"}`),
+		Entry("IPAM field takes precedence over CidrPoolRef", "my-pool", `{"type":"custom"}`, `{"type":"custom"}`),
+	)
+
+	It("sets object metadata correctly", func() {
+		rt := &v1alpha2.RailTopology{Name: "rail-1", MTU: 9000}
+		ovs := r.generateOVSNetwork(&v1alpha2.SpectrumXRailPoolConfigSpec{}, rt, false, false, namespace)
+		Expect(ovs.Name).To(Equal("rail-1"))
+		Expect(ovs.Namespace).To(Equal(namespace))
+		Expect(ovs.Spec.ResourceName).To(Equal("rail-1"))
+	})
+
+	It("sets MTU and interface type", func() {
+		rt := &v1alpha2.RailTopology{Name: "rail-1", MTU: 9000}
+		ovs := r.generateOVSNetwork(&v1alpha2.SpectrumXRailPoolConfigSpec{}, rt, false, false, namespace)
+		Expect(ovs.Spec.MTU).To(Equal(uint(9000)))
+		Expect(ovs.Spec.InterfaceType).To(Equal(ovsNetworkInterfaceType))
+	})
+
+	// MetaPluginsConfig is injected verbatim as array elements inside the plugins array of the
+	// OVS CNI NAD template (see ovs-cni-config.yaml). Wrapping it in [...] replicates that
+	// context and confirms the rendered output is valid JSON regardless of plugin count.
+	DescribeTable("MetaPluginsConfig produces valid JSON array elements",
+		func(addVRF bool) {
+			rt := &v1alpha2.RailTopology{Name: "rail-1", MTU: 9000}
+			ovs := r.generateOVSNetwork(&v1alpha2.SpectrumXRailPoolConfigSpec{}, rt, false, addVRF, namespace)
+			Expect(json.Valid([]byte("[" + ovs.Spec.MetaPluginsConfig + "]"))).To(BeTrue(),
+				"MetaPluginsConfig must be valid JSON array elements; got: %s", ovs.Spec.MetaPluginsConfig)
+		},
+		Entry("single plugin (addVRF=false)", false),
+		Entry("two plugins (addVRF=true)", true),
+	)
+})
+
+var _ = Describe("isCidrPoolIPv6", func() {
+	const (
+		nsName   = "ipv6-test-ns"
+		poolName = "test-cidrpool"
+	)
+
+	var (
+		r          *SpectrumXRailPoolConfigHostFlowsReconciler
+		fakeClient *fake.ClientBuilder
+	)
+
+	BeforeEach(func() {
+		fakeClient = fake.NewClientBuilder().WithScheme(scheme.Scheme)
+		r = &SpectrumXRailPoolConfigHostFlowsReconciler{Client: fakeClient.Build()}
+	})
+
+	createCIDRPool := func(name, namespace, cidr string) {
+		pool := &uns.Unstructured{}
+		pool.SetAPIVersion("nv-ipam.nvidia.com/v1alpha1")
+		pool.SetKind("CIDRPool")
+		pool.SetName(name)
+		pool.SetNamespace(namespace)
+		Expect(uns.SetNestedField(pool.Object, cidr, "spec", "cidr")).To(Succeed())
+		Expect(r.Client.Create(ctx, pool)).To(Succeed())
+	}
+
+	It("returns false for an IPv4 CIDR", func() {
+		createCIDRPool(poolName, nsName, "192.168.0.0/24")
+		result, err := r.isCidrPoolIPv6(ctx, poolName, nsName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeFalse())
+	})
+
+	It("returns true for an IPv6 CIDR", func() {
+		createCIDRPool(poolName, nsName, "fd00::/64")
+		result, err := r.isCidrPoolIPv6(ctx, poolName, nsName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeTrue())
+	})
+
+	It("returns true for an IPv6 /128 CIDR", func() {
+		createCIDRPool(poolName, nsName, "2001:db8::1/128")
+		result, err := r.isCidrPoolIPv6(ctx, poolName, nsName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeTrue())
+	})
+
+	It("returns error when the CIDRPool is not found", func() {
+		_, err := r.isCidrPoolIPv6(ctx, "nonexistent", nsName)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to get CIDRPool"))
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("returns error when the CIDR is invalid", func() {
+		createCIDRPool(poolName, nsName, "not-a-cidr")
+		_, err := r.isCidrPoolIPv6(ctx, poolName, nsName)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to parse CIDR"))
+	})
+
+	It("returns error when spec.cidr is absent", func() {
+		pool := &uns.Unstructured{}
+		pool.SetAPIVersion("nv-ipam.nvidia.com/v1alpha1")
+		pool.SetKind("CIDRPool")
+		pool.SetName(poolName)
+		pool.SetNamespace(nsName)
+		Expect(r.Client.Create(ctx, pool)).To(Succeed())
+
+		_, err := r.isCidrPoolIPv6(ctx, poolName, nsName)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("spec.cidr not found"))
+	})
+
+	It("returns error when spec.cidr has wrong type", func() {
+		pool := &uns.Unstructured{}
+		pool.SetAPIVersion("nv-ipam.nvidia.com/v1alpha1")
+		pool.SetKind("CIDRPool")
+		pool.SetName(poolName)
+		pool.SetNamespace(nsName)
+		Expect(uns.SetNestedField(pool.Object, int64(42), "spec", "cidr")).To(Succeed())
+		Expect(r.Client.Create(ctx, pool)).To(Succeed())
+
+		_, err := r.isCidrPoolIPv6(ctx, poolName, nsName)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to read spec.cidr"))
+	})
+})
+
+var _ = Describe("cidrPoolToRailConfigs", func() {
+	const (
+		nsName = "cidrpool-lister-ns"
+	)
+
+	var r *SpectrumXRailPoolConfigHostFlowsReconciler
+
+	newRPC := func(name, namespace, cidrPoolRef string) *v1alpha2.SpectrumXRailPoolConfig {
+		return &v1alpha2.SpectrumXRailPoolConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: v1alpha2.SpectrumXRailPoolConfigSpec{
+				NumVfs: 1,
+				RailTopology: []v1alpha2.RailTopology{{
+					Name:        "rail-1",
+					CidrPoolRef: cidrPoolRef,
+					NicSelector: v1alpha2.NicSelector{PfNames: []string{"eth0"}},
+				}},
+			},
+		}
+	}
+
+	cidrPoolObj := func(name, namespace string) client.Object {
+		pool := &uns.Unstructured{}
+		pool.SetAPIVersion("nv-ipam.nvidia.com/v1alpha1")
+		pool.SetKind("CIDRPool")
+		pool.SetName(name)
+		pool.SetNamespace(namespace)
+		return pool
+	}
+
+	BeforeEach(func() {
+		fc := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+		r = &SpectrumXRailPoolConfigHostFlowsReconciler{Client: fc}
+	})
+
+	It("enqueues the RPC that references the CIDRPool", func() {
+		rpc := newRPC("rpc-1", nsName, "my-pool")
+		Expect(r.Client.Create(ctx, rpc)).To(Succeed())
+
+		requests := r.cidrPoolToRailConfigs(ctx, cidrPoolObj("my-pool", nsName))
+		Expect(requests).To(ConsistOf(reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: nsName, Name: "rpc-1"},
+		}))
+	})
+
+	It("does not enqueue RPCs with a different CidrPoolRef", func() {
+		rpc := newRPC("rpc-other", nsName, "other-pool")
+		Expect(r.Client.Create(ctx, rpc)).To(Succeed())
+
+		requests := r.cidrPoolToRailConfigs(ctx, cidrPoolObj("my-pool", nsName))
+		Expect(requests).To(BeEmpty())
+	})
+
+	It("does not enqueue RPCs with no CidrPoolRef", func() {
+		rpc := newRPC("rpc-no-ref", nsName, "")
+		Expect(r.Client.Create(ctx, rpc)).To(Succeed())
+
+		requests := r.cidrPoolToRailConfigs(ctx, cidrPoolObj("my-pool", nsName))
+		Expect(requests).To(BeEmpty())
+	})
+
+	It("enqueues only the matching RPC among multiple", func() {
+		rpc1 := newRPC("rpc-match", nsName, "my-pool")
+		rpc2 := newRPC("rpc-no-match", nsName, "other-pool")
+		Expect(r.Client.Create(ctx, rpc1)).To(Succeed())
+		Expect(r.Client.Create(ctx, rpc2)).To(Succeed())
+
+		requests := r.cidrPoolToRailConfigs(ctx, cidrPoolObj("my-pool", nsName))
+		Expect(requests).To(ConsistOf(reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: nsName, Name: "rpc-match"},
+		}))
+	})
+
+	It("does not enqueue RPCs from a different namespace", func() {
+		rpc := newRPC("rpc-other-ns", "other-ns", "my-pool")
+		Expect(r.Client.Create(ctx, rpc)).To(Succeed())
+
+		requests := r.cidrPoolToRailConfigs(ctx, cidrPoolObj("my-pool", nsName))
+		Expect(requests).To(BeEmpty())
+	})
+})

--- a/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
+++ b/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net"
 
 	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/apply"
@@ -120,6 +121,7 @@ func NewSpectrumXRailPoolConfigHostFlowsReconciler(
 // +kubebuilder:rbac:groups=sriovnetwork.openshift.io,resources=ovsnetworks,verbs=create;patch;get;list;watch;update;delete
 // +kubebuilder:rbac:groups=sriovnetwork.openshift.io,resources=sriovnetworknodestates,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=nv-ipam.nvidia.com,resources=cidrpools,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -227,7 +229,21 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) reconcileRailTopology(ctx c
 	}
 
 	addBridge := len(rt.NicSelector.PfNames) > 1
-	ovsNetwork := r.generateOVSNetwork(spec, &rt, addBridge, namespace)
+
+	addVRF := false
+	if rt.CidrPoolRef != "" {
+		isIPv6, err := r.isCidrPoolIPv6(ctx, rt.CidrPoolRef, namespace)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed to check CIDRPool %s for IPv6: %w", rt.CidrPoolRef, err)
+			}
+			// CIDRPool not found: clear VRF and proceed so unrelated updates are not blocked.
+		} else {
+			addVRF = isIPv6
+		}
+	}
+
+	ovsNetwork := r.generateOVSNetwork(spec, &rt, addBridge, addVRF, namespace)
 	ovsNetwork.SetGroupVersionKind(sriovv1.GroupVersion.WithKind(sriovOVSNetworkType))
 	ovsNetwork.Labels = ownerLabels
 	if err := r.Patch(ctx, ovsNetwork, client.Apply, client.ForceOwnership, client.FieldOwner(SpectrumXRailPoolConfigControllerName)); err != nil {
@@ -679,7 +695,49 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateSRIOVNetworkNodePol
 	return nodePolicy
 }
 
-func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateOVSNetwork(spec *v1alpha2.SpectrumXRailPoolConfigSpec, rt *v1alpha2.RailTopology, addBridge bool, namespace string) *sriovv1.OVSNetwork {
+func (r *SpectrumXRailPoolConfigHostFlowsReconciler) cidrPoolToRailConfigs(ctx context.Context, obj client.Object) []reconcile.Request {
+	logger := log.FromContext(ctx)
+	list := &v1alpha2.SpectrumXRailPoolConfigList{}
+	if err := r.List(ctx, list, client.InNamespace(obj.GetNamespace())); err != nil {
+		logger.Error(err, "failed to list SpectrumXRailPoolConfigs for CIDRPool", "cidrpool", obj.GetName())
+		return nil
+	}
+	var requests []reconcile.Request
+	for _, rpc := range list.Items {
+		for _, rt := range rpc.Spec.RailTopology {
+			if rt.CidrPoolRef == obj.GetName() {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: rpc.Namespace, Name: rpc.Name},
+				})
+				break
+			}
+		}
+	}
+	return requests
+}
+
+func (r *SpectrumXRailPoolConfigHostFlowsReconciler) isCidrPoolIPv6(ctx context.Context, name, namespace string) (bool, error) {
+	cidrPool := &uns.Unstructured{}
+	cidrPool.SetAPIVersion("nv-ipam.nvidia.com/v1alpha1")
+	cidrPool.SetKind("CIDRPool")
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, cidrPool); err != nil {
+		return false, fmt.Errorf("failed to get CIDRPool %s/%s: %w", namespace, name, err)
+	}
+	cidr, found, err := uns.NestedString(cidrPool.Object, "spec", "cidr")
+	if err != nil {
+		return false, fmt.Errorf("failed to read spec.cidr from CIDRPool %s/%s: %w", namespace, name, err)
+	}
+	if !found {
+		return false, fmt.Errorf("spec.cidr not found in CIDRPool %s/%s", namespace, name)
+	}
+	ip, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse CIDR %q from CIDRPool %s/%s: %w", cidr, namespace, name, err)
+	}
+	return ip.To4() == nil, nil
+}
+
+func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateOVSNetwork(spec *v1alpha2.SpectrumXRailPoolConfigSpec, rt *v1alpha2.RailTopology, addBridge bool, addVRF bool, namespace string) *sriovv1.OVSNetwork {
 	var ipam string
 	switch {
 	case rt.IPAM != "":
@@ -689,6 +747,11 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateOVSNetwork(spec *v1
 	}
 
 	rdmDeviceName := fmt.Sprintf("rdma_%s", rt.Name)
+
+	metaPlugins := fmt.Sprintf(`{"type": "rdma", "rdmaQoS": {"tos": %d,"tc": %d}, "args": {"cni": {"rdmaDeviceName": "%s"}}}`, rdmaQoSToS, rdmaQoSTC, rdmDeviceName)
+	if addVRF {
+		metaPlugins += fmt.Sprintf(`, {"type": "vrf", "vrfname": %q}`, rt.Name)
+	}
 
 	ovsNetwork := &sriovv1.OVSNetwork{
 		ObjectMeta: metav1.ObjectMeta{
@@ -701,7 +764,7 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) generateOVSNetwork(spec *v1
 			NetworkNamespace:  spec.NetworkNamespace,
 			MTU:               uint(rt.MTU), //nolint:gosec // MTU is always non-negative
 			IPAM:              ipam,
-			MetaPluginsConfig: fmt.Sprintf(`{"type": "rdma", "rdmaQoS": {"tos": %d,"tc": %d}, "args": {"cni": {"rdmaDeviceName": "%s"}}}`, rdmaQoSToS, rdmaQoSTC, rdmDeviceName),
+			MetaPluginsConfig: metaPlugins,
 		},
 	}
 	if addBridge {
@@ -722,6 +785,10 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) SetupWithManager(
 		return nodeName == obj.GetName()
 	})
 
+	cidrPool := &uns.Unstructured{}
+	cidrPool.SetAPIVersion("nv-ipam.nvidia.com/v1alpha1")
+	cidrPool.SetKind("CIDRPool")
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha2.SpectrumXRailPoolConfig{}). // TODO: only reconcile objects that are related to this node
 		Watches(
@@ -730,6 +797,11 @@ func (r *SpectrumXRailPoolConfigHostFlowsReconciler) SetupWithManager(
 			builder.WithPredicates(
 				predicate.And(predicate.LabelChangedPredicate{}, nodeNameFilter),
 			),
+		).
+		Watches(
+			cidrPool,
+			handler.EnqueueRequestsFromMapFunc(r.cidrPoolToRailConfigs),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		WatchesRawSource(source.Channel(ovsWatcher, railListerHandler)).
 		Named("spectrumxrailpoolconfig-host-flows").Complete(reconcile.AsReconciler[*v1alpha2.SpectrumXRailPoolConfig](r.Client, r))


### PR DESCRIPTION
When a RailTopology references a CIDRPool and the pool's CIDR is IPv6, the OVSNetwork NetworkAttachmentDefinition now includes a VRF meta-plugin alongside the existing RDMA plugin, using the rail topology name as the VRF name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added conditional VRF meta-plugin support per rail topology: when a referenced CIDR pool is IPv6, VRF configuration is enabled (with VRF name aligned to the rail topology).

- **RBAC / Permissions**
  - Expanded ClusterRole and OpenShift Role permissions to allow `get`, `list`, and `watch` on `cidrpools` (`nv-ipam.nvidia.com`).

- **Controller Enhancements**
  - Updated reconciliation so changes to referenced CIDR pools trigger reconciliation for affected rail pool configurations.

- **Tests**
  - Added Ginkgo/Gomega coverage for meta-plugin generation, CIDR pool IPv4/IPv6 detection, and enqueue behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->