### PR TITLE
feat: add Status and Age printer columns to SpectrumXRailPoolConfig CRD

### DIFF
--- a/api/v1alpha2/spectrumxrailpoolconfig_types.go
+++ b/api/v1alpha2/spectrumxrailpoolconfig_types.go
@@ -79,6 +79,8 @@ type SpectrumXRailPoolConfigStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.syncStatus`,priority=0
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,priority=0
 
 // SpectrumXRailPoolConfig is the Schema for the spectrumxrailpoolconfigs API.
 type SpectrumXRailPoolConfig struct {

--- a/config/crd/bases/spectrumx.nvidia.com_spectrumxrailpoolconfigs.yaml
+++ b/config/crd/bases/spectrumx.nvidia.com_spectrumxrailpoolconfigs.yaml
@@ -14,7 +14,14 @@ spec:
     singular: spectrumxrailpoolconfig
   scope: Namespaced
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .status.syncStatus
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: SpectrumXRailPoolConfig is the Schema for the spectrumxrailpoolconfigs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added kubectl table columns to the `SpectrumXRailPoolConfig` resource view for **Status** and **Age**.
  * These columns now show the current sync state and resource creation time when listing resources, improving at-a-glance monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->