### PR TITLE
feat: switch OVS network interface type from dpdk to doca

### DIFF
--- a/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
+++ b/internal/controller/spectrumxrailpoolconfig_host_flows_controller.go
@@ -66,7 +66,7 @@ const (
 	sriovNetworkPoolConfig  = "SriovNetworkPoolConfig"
 	sriovOVSNetworkType     = "OVSNetwork"
 	ovsDataPathType         = "netdev"
-	ovsNetworkInterfaceType = "dpdk"
+	ovsNetworkInterfaceType = "doca"
 )
 
 const (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the network interface type used for generated OVS network resources, aligning them with the correct supported configuration.
  * This helps ensure network setups are created with the expected interface type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->