### PR TITLE
ci: remove netop CI branch trigger

### DIFF
--- a/.github/workflows/netop-ci.yml
+++ b/.github/workflows/netop-ci.yml
@@ -2,8 +2,6 @@ name: Fork CI
 
 on:
   push:
-    branches:
-      - network-operator-*
     tags:
       - network-operator-*
 


### PR DESCRIPTION
## Summary
- remove the `network-operator-*` branch trigger from the reusable fork-ci workflow on this release branch
- keep `network-operator-*` tag triggers for release builds

## Verification
- YAML parse check for `.github/workflows/netop-ci.*`
- `git diff --check`